### PR TITLE
Add the flag zip_safe to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,5 @@ setup(
               'numpy',
           ],
     scripts=scripts,
+    zip_safe=True
 )


### PR DESCRIPTION
Hi, 

I don't know much about the `python setup.py install` dance but when I wanted to try RaGOO, the setup process lamented about a `zip_safe` flag not being present or something. I was able to compile when I added this flag to the setup.py description so …
Maybe this should be added, or maybe I am doing something wrong ;)

Congrats on your preprint; RaGOO looks really useful, impatient to try it out.